### PR TITLE
ロゴの取得をmongoDBへ変更

### DIFF
--- a/server/routes/Sector.js
+++ b/server/routes/Sector.js
@@ -31,12 +31,11 @@ router.get('/:sectorId/:sectorName', async (req, res) => {
         try{
           await Promise.all([
             getStockData.getStockQuote(stockList[index]["symbol"]),
-            getStockData.getStockLogo(stockList[index]["symbol"]),
         ])
           .then(function (results) {
             //close(終値)とpreviousClose(前日終値)の差分を追加
               let addedQuote = Object.assign(results[0], {close_previousClose_diff :results[0]['close'] - results[0]['previousClose']})
-              let quoteAndLogo = Object.assign(addedQuote, results[1])
+              let quoteAndLogo = Object.assign(addedQuote, {url :stockList[index]['logo_url']})
               const returnKeys = [
                 'symbol',
                 'url',


### PR DESCRIPTION
セクター一覧APIのロゴ取得を外部API叩かなくてよくなった