### PR TITLE
[INVEST-51を先にマージして]チャート用のデータを返すバックエンドAPIを実装

### DIFF
--- a/server/apis/getStockData.js
+++ b/server/apis/getStockData.js
@@ -10,6 +10,15 @@ async function execStockApi(symbol, type){
     });
 }
 
+async function execSimpleChartApi(symbol, range) {
+    return new Promise(function (resolve, reject) {
+        axios
+            .get(process.env.IEX_API_SANDBOX_BASE_URL + 'stock/' + symbol + '/chart/' + range + '?chartCloseOnly=true&token=' + process.env.IEX_SANDBOX_SECRET_TOKEN)
+            .then(response => resolve(response.data))
+            .catch(error => reject(error.response))
+    })
+}
+
 exports.getStockQuote = function(symbol){
     return execStockApi(symbol, "quote")
 }
@@ -24,4 +33,8 @@ exports.getStockStats = function(symbol) {
 
 exports.getStockAdvancedStats = function(symbol) {
     return execStockApi(symbol, 'advanced-stats')
+}
+
+exports.getSimpleChartData = function(symbol, range) {
+    return execSimpleChartApi(symbol, range)
 }

--- a/server/routes/Symbol.js
+++ b/server/routes/Symbol.js
@@ -51,6 +51,31 @@ router.get('/:symbol', async (req, res) => {
         });
 })
 
+router.get('/basic-chart/:symbol/:range', async (req, res) => {
+    const symbol = req.params.symbol
+    const range = req.params.range
+    Promise.all([ 
+        getStockData.getSimpleChartData(symbol, range),
+    ])
+        .then(function (results) {
+            const date = [];
+            const dataContent = {}
+            for (let index = 0;index<results[0].length; index++) {
+                date.push(results[0][index]['date'])
+                dataContent[results[0][index]['date']] = results[0][index]
+                //dataContentで返す必要がない物を除く
+                delete results[0][index].date;
+                delete results[0][index].changeOverTime;
+            };
+            const finalResponse = {
+                label: date,
+                data: dataContent
+            }
+            res.json(JSON.stringify(finalResponse))
+        });
+})
+
+
 router.get('/test/:symbol', (req, res)=>{
     res.json({
         "symbol": "APPL",

--- a/server/routes/Symbol.js
+++ b/server/routes/Symbol.js
@@ -9,7 +9,7 @@ router.use(express.json());
 
 router.get('/:symbol', async (req, res) => {
     //正規表現で小文字も許容する　ex)AAPL:aapl
-    let stock = await Stock.find({"symbol":new RegExp(String.raw`^${req.params.symbol}$`, "i")});
+    const stock = await Stock.find({"symbol":new RegExp(String.raw`^${req.params.symbol}$`, "i")});
     const symbol = req.params.symbol
     Promise.all([ 
         getStockData.getStockQuote(symbol),
@@ -17,9 +17,9 @@ router.get('/:symbol', async (req, res) => {
     ])
         .then(function (results) {
             //close(終値)とpreviousClose(前日終値)の差分を追加
-            let addedQuote = Object.assign(results[0], {close_previousClose_diff :results[0]['close'] - results[0]['previousClose']})
-            let quoteAndLogo = Object.assign(addedQuote, {url : stock.length > 0 ? stock[0]['logo_url'] : undefined})
-            let allGetData = Object.assign(quoteAndLogo, results[1])
+            const addedQuote = Object.assign(results[0], {close_previousClose_diff :results[0]['close'] - results[0]['previousClose']})
+            const quoteAndLogo = Object.assign(addedQuote, {url : stock.length > 0 ? stock[0]['logo_url'] : undefined})
+            const allGetData = Object.assign(quoteAndLogo, results[1])
             const returnKeys = [
                 'symbol',
                 'url',

--- a/server/routes/Symbol.js
+++ b/server/routes/Symbol.js
@@ -54,25 +54,27 @@ router.get('/:symbol', async (req, res) => {
 router.get('/basic-chart/:symbol/:range', async (req, res) => {
     const symbol = req.params.symbol
     const range = req.params.range
-    Promise.all([ 
-        getStockData.getSimpleChartData(symbol, range),
-    ])
+
+    new Promise((resolve) => {
+        resolve(getStockData.getSimpleChartData(symbol, range))
+    })
         .then(function (results) {
             const date = [];
             const dataContent = {}
-            for (let index = 0;index<results[0].length; index++) {
-                date.push(results[0][index]['date'])
-                dataContent[results[0][index]['date']] = results[0][index]
+            for (let index = 0;index<results.length; index++) {
+                date.push(results[index]['date'])
+                dataContent[results[index]['date']] = results[index]
                 //dataContentで返す必要がない物を除く
-                delete results[0][index].date;
-                delete results[0][index].changeOverTime;
+                delete results[index].date;
+                delete results[index].changeOverTime;
             };
             const finalResponse = {
                 label: date,
                 data: dataContent
             }
             res.json(JSON.stringify(finalResponse))
-        });
+        })
+        .catch(err => console.log(err));
 })
 
 


### PR DESCRIPTION
エンドポイント
###
GET http://127.0.0.1:3000/api/symbol/basic-chart/:symbol/:range

例）アップル社の過去１年分のデータ
```
http://127.0.0.1:3000/api/symbol/basic-chart/AAPL/1y
```

レスポンスのデータ構造は↓こんな感じ
```
{
  label: ["2020-05-20", "2020-05-20", "2020-05-20", "2020-05-20", "2020-05-20"]
  data:{
    "2020-05-11"[
      close: 109.27,
      volume: 6529136,
      change: 0.3241345678614231,
      changePercent: 0.0028
    ],
    "2020-05-11"[
      close: 109.27,
      volume: 6529136,
      change: 0.3241345678614231,
      changePercent: 0.0028
    ],
    "2020-05-11"[
      close: 109.27,
      volume: 6529136,
      change: 0.3241345678614231,
      changePercent: 0.0028
    ],
    "2020-05-11"[
      close: 109.27,
      volume: 6529136,
      change: 0.3241345678614231,
      changePercent: 0.0028
    ],
    "2020-05-11"[
      close: 109.27,
      volume: 6529136,
      change: 0.3241345678614231,
      changePercent: 0.0028
    ],
  }
}
```

:rangeの部分に入れられる期間は↓こんな感じ
例）
５日間→5d
1ヶ月→1m
詳細↓
RANGE | DESCRIPTION | SOURCE
max | All available data up to 15 years | Historically adjusted market-wide data
5y | Five years | Historically adjusted market-wide data
2y | Two years | Historically adjusted market-wide data
1y | One year | Historically adjusted market-wide data
ytd | Year-to-date | Historically adjusted market-wide data
6m | Six months | Historically adjusted market-wide data
3m | Three months | Historically adjusted market-wide data
1m | One month (default) | Historically adjusted market-wide data
1mm | One month | Historically adjusted market-wide data in 30 minute intervals
5d | Five Days | Historically adjusted market-wide data by day.
5dm | Five Days | Historically adjusted market-wide data in 10 minute intervals
参照：
https://iexcloud.io/docs/api/#historical-prices
